### PR TITLE
Add architecture docs and launch scripts for unified adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,30 @@ El sistema se basará en una arquitectura de microservicios, con un "puente" (se
 ## Estado Actual
 
 Proyecto en fase de inicialización. El primer objetivo es implementar el `mcp_unity_bridge`.
+
+## Ejemplos de ejecución
+
+### Unity Bridge
+```sh
+python -m mcp_unity_server.main
+```
+
+### Blender Bridge
+```sh
+blender --background --python mcp_blender_bridge/mcp_blender_addon/websocket_server.py
+```
+
+### Adaptador unificado
+```sh
+python mcp_unity_bridge/mcp_adapter.py
+```
+
+También puedes lanzar todo el stack con:
+```sh
+./launch_unified_adapter.sh
+```
+ o en Windows:
+```bat
+launch_unified_adapter.bat
+```
+

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,23 @@
+# Arquitectura
+
+El proyecto se organiza en tres componentes principales que permiten a un agente de IA controlar distintas aplicaciones de desarrollo de videojuegos:
+
+## Adaptador unificado
+
+- Expone las herramientas del proyecto mediante el protocolo MCP.
+- Actúa como fachada entre el agente de IA y los distintos bridges.
+- Se ejecuta con `python mcp_unity_bridge/mcp_adapter.py` y enruta las peticiones a los servicios disponibles.
+
+## Unity Bridge
+
+- Servidor FastAPI que mantiene un canal WebSocket con el editor de Unity.
+- Traduce las peticiones del adaptador en comandos o consultas C# para Unity.
+- Se lanza con `python -m mcp_unity_server.main` desde el directorio `mcp_unity_bridge`.
+
+## Blender Bridge
+
+- Add-on de Blender con un pequeño servidor WebSocket.
+- Permite que el adaptador invoque acciones sobre Blender mediante Python (`bpy`).
+- Puede iniciarse con Blender en modo consola: `blender --background --python mcp_blender_bridge/mcp_blender_addon/websocket_server.py`.
+
+Estos tres procesos conforman el stack mínimo para que el agente de IA interactúe con los editores.

--- a/launch_unified_adapter.bat
+++ b/launch_unified_adapter.bat
@@ -1,0 +1,18 @@
+@echo off
+REM Inicia Unity Bridge, Blender Bridge y el adaptador MCP unificado.
+setlocal
+cd /d "%~dp0"
+
+REM Asegurar que el servidor de Unity pueda importarse
+set "PYTHONPATH=%CD%\mcp_unity_bridge\src;%PYTHONPATH%"
+
+REM Lanzar Unity Bridge en segundo plano
+start "Unity Bridge" cmd /c "python -m mcp_unity_server.main"
+
+REM Lanzar Blender Bridge (requiere 'blender' en el PATH)
+start "Blender Bridge" cmd /c "blender --background --python mcp_blender_bridge\mcp_blender_addon\websocket_server.py"
+
+REM Lanzar el adaptador unificado en primer plano
+python mcp_unity_bridge\mcp_adapter.py
+
+endlocal

--- a/launch_unified_adapter.sh
+++ b/launch_unified_adapter.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Inicia Unity Bridge, Blender Bridge y el adaptador MCP unificado.
+set -e
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$ROOT_DIR"
+
+# Asegurar que el servidor de Unity pueda importarse
+export PYTHONPATH="$ROOT_DIR/mcp_unity_bridge/src:$PYTHONPATH"
+
+# Lanzar Unity Bridge en segundo plano
+python -m mcp_unity_server.main &
+UNITY_PID=$!
+
+echo "Unity Bridge iniciado (PID $UNITY_PID)"
+
+# Lanzar Blender Bridge (requiere 'blender' en el PATH)
+blender --background --python mcp_blender_bridge/mcp_blender_addon/websocket_server.py &
+BLENDER_PID=$!
+
+echo "Blender Bridge iniciado (PID $BLENDER_PID)"
+
+# Lanzar el adaptador unificado en primer plano
+python mcp_unity_bridge/mcp_adapter.py
+
+# Al salir, detener los bridges
+kill $UNITY_PID $BLENDER_PID 2>/dev/null || true


### PR DESCRIPTION
## Summary
- Document architecture of unified MCP adapter with Unity and Blender bridges
- Add execution examples for Unity Bridge, Blender Bridge, and unified adapter
- Provide launch scripts to start the full stack

## Testing
- `bash -n launch_unified_adapter.sh`
- `python -m py_compile mcp_unity_bridge/mcp_adapter.py mcp_unity_bridge/src/mcp_unity_server/main.py`


------
https://chatgpt.com/codex/tasks/task_e_68ae778ccb54832391e7c36849bc372e