### PR TITLE
Add Blender macro framework with dynamic execution

### DIFF
--- a/mcp_blender_bridge/mcp_blender_addon/README.md
+++ b/mcp_blender_bridge/mcp_blender_addon/README.md
@@ -39,3 +39,25 @@ Blender 2.79 viene con su propio intérprete de Python. Para instalar `websocket
     Y luego intenta instalar `websockets` de nuevo.
 
 Una vez que la instalación se haya completado, el add-on debería funcionar correctamente la próxima vez que habilites el add-on en Blender.
+
+## Macros
+
+El complemento incluye un sistema de *macros* que permite extender las operaciones disponibles.
+Cada macro es un archivo `.py` dentro de `macros/` que expone una función pública `run(**kwargs)`.
+
+Ejemplo de llamada por WebSocket:
+
+```json
+{
+  "command": "run_macro",
+  "params": {"name": "extrude_mesh", "object_name": "Cube", "distance": 1.0}
+}
+```
+
+Para crear un nuevo macro:
+
+1. Crea un archivo dentro de `macros/` con un nombre único, por ejemplo `mi_macro.py`.
+2. Define en ese archivo una función `run(**kwargs)` que realice la operación deseada.
+3. Desde el cliente envía el comando `run_macro` con `name` igual al nombre del archivo (sin `.py`).
+
+Se incluyen macros de ejemplo: `extrude_mesh`, `apply_boolean` y `assign_material`.

--- a/mcp_blender_bridge/mcp_blender_addon/macros/__init__.py
+++ b/mcp_blender_bridge/mcp_blender_addon/macros/__init__.py
@@ -1,0 +1,4 @@
+"""Colección de macros de Blender.
+
+Cada macro es un módulo con una función pública ``run(**kwargs)``.
+"""

--- a/mcp_blender_bridge/mcp_blender_addon/macros/apply_boolean.py
+++ b/mcp_blender_bridge/mcp_blender_addon/macros/apply_boolean.py
@@ -1,0 +1,23 @@
+"""Aplica un modificador booleano entre dos objetos."""
+
+try:  # pragma: no cover - dependencia de Blender
+    import bpy  # type: ignore
+except Exception:  # pragma: no cover
+    bpy = None
+
+
+def run(target_name, cutter_name, operation="UNION"):
+    """Aplica un booleano del tipo ``operation``."""
+    if bpy is None:  # pragma: no cover
+        print("bpy no disponible: apply_boolean es un stub")
+        return True
+    target = bpy.data.objects.get(target_name)
+    cutter = bpy.data.objects.get(cutter_name)
+    if target is None or cutter is None:
+        raise ValueError("Objetos especificados no encontrados")
+    modifier = target.modifiers.new(name="Boolean", type="BOOLEAN")
+    modifier.object = cutter
+    modifier.operation = operation
+    bpy.context.view_layer.objects.active = target
+    bpy.ops.object.modifier_apply(modifier=modifier.name)
+    return target.name

--- a/mcp_blender_bridge/mcp_blender_addon/macros/assign_material.py
+++ b/mcp_blender_bridge/mcp_blender_addon/macros/assign_material.py
@@ -1,0 +1,24 @@
+"""Asigna un material a un objeto."""
+
+try:  # pragma: no cover - dependencia de Blender
+    import bpy  # type: ignore
+except Exception:  # pragma: no cover
+    bpy = None
+
+
+def run(object_name, material_name):
+    """Asigna ``material_name`` a ``object_name``."""
+    if bpy is None:  # pragma: no cover
+        print("bpy no disponible: assign_material es un stub")
+        return True
+    obj = bpy.data.objects.get(object_name)
+    if obj is None:
+        raise ValueError("Objeto '{0}' no encontrado".format(object_name))
+    mat = bpy.data.materials.get(material_name)
+    if mat is None:
+        mat = bpy.data.materials.new(material_name)
+    if obj.data.materials:
+        obj.data.materials[0] = mat
+    else:
+        obj.data.materials.append(mat)
+    return mat.name

--- a/mcp_blender_bridge/mcp_blender_addon/macros/extrude_mesh.py
+++ b/mcp_blender_bridge/mcp_blender_addon/macros/extrude_mesh.py
@@ -1,0 +1,24 @@
+"""Extrude una malla a lo largo del eje Z."""
+
+try:  # pragma: no cover - dependencia de Blender
+    import bpy  # type: ignore
+except Exception:  # pragma: no cover
+    bpy = None
+
+
+def run(object_name, distance=1.0):
+    """Extrude la malla ``object_name`` una distancia dada."""
+    if bpy is None:  # pragma: no cover
+        print("bpy no disponible: extrude_mesh es un stub")
+        return True
+    obj = bpy.data.objects.get(object_name)
+    if obj is None:
+        raise ValueError("Objeto '{0}' no encontrado".format(object_name))
+    bpy.context.view_layer.objects.active = obj
+    bpy.ops.object.mode_set(mode="EDIT")
+    bpy.ops.mesh.select_all(action="SELECT")
+    bpy.ops.mesh.extrude_region_move(
+        TRANSFORM_OT_translate={"value": (0, 0, distance)}
+    )
+    bpy.ops.object.mode_set(mode="OBJECT")
+    return obj.name


### PR DESCRIPTION
## Summary
- add `macros/` package with example macros: extrude_mesh, apply_boolean, assign_material
- support executing macros via new `run_macro` command in `websocket_server`
- document how to create and invoke macros through WebSocket

## Testing
- `python -m py_compile mcp_blender_bridge/mcp_blender_addon/websocket_server.py mcp_blender_bridge/mcp_blender_addon/macros/extrude_mesh.py mcp_blender_bridge/mcp_blender_addon/macros/apply_boolean.py mcp_blender_bridge/mcp_blender_addon/macros/assign_material.py && echo py_compile_ok`
- `pytest >/tmp/pytest.log && tail -n 20 /tmp/pytest.log` *(fails: ConnectionRefusedError connecting to 127.0.0.1:8001)*

------
https://chatgpt.com/codex/tasks/task_e_68ae98a4035c8323a1a4e2835ec8846a