### PR TITLE
Document remote Blender execution and add macro examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,3 +64,47 @@ También puedes lanzar todo el stack con:
 launch_unified_adapter.bat
 ```
 
+
+## Ejecución remota en Blender
+
+### `execute_python` / `execute_python_file`
+
+El servidor WebSocket puede evaluar código Python enviado por el cliente.
+
+```python
+await websocket.send(json.dumps({"command": "execute_python", "params": {"code": "print('hola')"}}))
+```
+
+Para ejecutar un archivo almacenado en la máquina que corre Blender:
+
+```python
+await websocket.send(json.dumps({"command": "execute_python_file", "params": {"path": "/ruta/script.py"}}))
+```
+
+### Macros
+
+Los macros son módulos dentro de `mcp_blender_bridge/mcp_blender_addon/macros` que definen una función `run(**kwargs)`.
+Se invocan con el comando `run_macro`.
+
+```python
+await websocket.send(json.dumps({
+    "command": "run_macro",
+    "params": {
+        "name": "assign_material",
+        "object_name": "Cube",
+        "material_name": "Demo"
+    }
+}))
+```
+
+### Cargar macros personalizados
+
+1. Crea un archivo Python en `mcp_blender_bridge/mcp_blender_addon/macros/` con un nombre único.
+2. Define en él una función `run(**kwargs)` que contenga la lógica del macro.
+3. Reinicia el servidor WebSocket si estaba en ejecución.
+4. Desde el cliente, llama a `run_macro` indicando el nombre del archivo sin `.py` y los parámetros necesarios.
+
+### Seguridad
+
+Ejecutar código remoto otorga acceso completo al entorno de Blender.
+Utiliza estas capacidades solo con scripts y macros de confianza y evita exponer el puerto a redes públicas.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -26,3 +26,28 @@ El proyecto se organiza en tres componentes principales que permiten a un agente
 - Los archivos generados se guardan en `unity_project/Assets/Generated/`, carpeta compartida con Unity para que el editor detecte los nuevos assets.
 
 Estos tres procesos conforman el stack mínimo para que el agente de IA interactúe con los editores.
+
+## Ejecución remota en Blender
+
+El servidor WebSocket del add-on de Blender expone comandos para ejecutar código Python dentro de la escena en curso.
+
+### `execute_python` y `execute_python_file`
+
+- `execute_python` evalúa un bloque de código enviado desde el cliente.
+- `execute_python_file` carga y ejecuta un archivo de script ubicado en la máquina donde corre Blender.
+
+### Macros
+
+Los macros son módulos almacenados en `mcp_blender_addon/macros` que definen una función `run(**kwargs)`.
+El comando `run_macro` importa el módulo solicitado y ejecuta dicha función.
+
+Ejemplo de petición:
+
+```json
+{"command": "run_macro", "params": {"name": "assign_material", "object_name": "Cube", "material_name": "Demo"}}
+```
+
+### Seguridad
+
+Tanto la ejecución de código como los macros pueden ejecutar instrucciones arbitrarias con los permisos del usuario que
+corre Blender. Sólo deben utilizarse con scripts de confianza y en entornos controlados.

--- a/mcp_blender_bridge/mcp_blender_addon/examples/add_material.py
+++ b/mcp_blender_bridge/mcp_blender_addon/examples/add_material.py
@@ -1,0 +1,29 @@
+import asyncio
+import json
+import time
+import websockets
+import os
+import sys
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+import websocket_server as ws
+
+async def main():
+    async with websockets.connect("ws://127.0.0.1:8002") as websocket:
+        await websocket.send(json.dumps({"command": "create_cube", "params": {"name": "CubeWithMat"}}))
+        print(await websocket.recv())
+        await websocket.send(json.dumps({
+            "command": "run_macro",
+            "params": {
+                "name": "assign_material",
+                "object_name": "CubeWithMat",
+                "material_name": "DemoMaterial"
+            }
+        }))
+        print(await websocket.recv())
+
+if __name__ == "__main__":
+    ws.start_server()
+    time.sleep(0.1)
+    asyncio.get_event_loop().run_until_complete(main())
+    ws.stop_server()

--- a/mcp_blender_bridge/mcp_blender_addon/examples/create_arch.py
+++ b/mcp_blender_bridge/mcp_blender_addon/examples/create_arch.py
@@ -1,0 +1,42 @@
+import asyncio
+import json
+import time
+import websockets
+import os
+import sys
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+import websocket_server as ws
+
+ARCH_CODE = '''
+import bpy
+
+# Crea dos pilares
+bpy.ops.mesh.primitive_cube_add(size=1, location=(-1, 0, 0.5))
+pillar1 = bpy.context.active_object
+bpy.ops.mesh.primitive_cube_add(size=1, location=(1, 0, 0.5))
+pillar2 = bpy.context.active_object
+
+# Crea el arco superior
+bpy.ops.mesh.primitive_cylinder_add(radius=1.2, depth=1, location=(0, 0, 1))
+arch_top = bpy.context.active_object
+
+# Une las piezas en un solo objeto
+bpy.ops.object.select_all(action='DESELECT')
+pillar1.select_set(True)
+pillar2.select_set(True)
+arch_top.select_set(True)
+bpy.context.view_layer.objects.active = pillar1
+bpy.ops.object.join()
+'''
+
+async def main():
+    async with websockets.connect("ws://127.0.0.1:8002") as websocket:
+        await websocket.send(json.dumps({"command": "execute_python", "params": {"code": ARCH_CODE}}))
+        print(await websocket.recv())
+
+if __name__ == "__main__":
+    ws.start_server()
+    time.sleep(0.1)
+    asyncio.get_event_loop().run_until_complete(main())
+    ws.stop_server()


### PR DESCRIPTION
## Summary
- add Blender examples for executing Python snippets and running macros
- document execute_python/execute_python_file, macro usage, and security considerations
- explain how to register and invoke custom macros

## Testing
- `python -m py_compile mcp_blender_bridge/mcp_blender_addon/examples/create_arch.py mcp_blender_bridge/mcp_blender_addon/examples/add_material.py`


------
https://chatgpt.com/codex/tasks/task_e_68ae99fc9aa883239166f05c63dd9f90