### PR TITLE
feat: add Blender execute_python tool

### DIFF
--- a/mcp_unity_bridge/mcp_adapter.py
+++ b/mcp_unity_bridge/mcp_adapter.py
@@ -303,6 +303,15 @@ async def generate_asset_and_import(name: str = "BlenderCube", filename: str = "
 
 
 @mcp.tool()
+async def blender_execute_python(code: str) -> str:
+    """Ejecuta código Python en Blender y retorna stdout y stderr."""
+    log.info("Blender execute_python")
+    message = {"command": "execute_python", "params": {"code": code}}
+    response = await send_to_blender_and_get_response(message)
+    return json.dumps(response, indent=2, ensure_ascii=False)
+
+
+@mcp.tool()
 async def blender_create_cube(
     name: str = "Cube", location: Tuple[float, float, float] = (0, 0, 0)
 ) -> str:


### PR DESCRIPTION
## Summary
- add blender_execute_python MCP tool to run Python code on Blender and forward stdout/stderr

## Testing
- `pytest -q` *(fails: ConnectionRefusedError: Connect call failed ('127.0.0.1', 8001))*

------
https://chatgpt.com/codex/tasks/task_e_68ae9de5be68832380569264aeca7100