### PR TITLE
Add Blender tool for executing Python files

### DIFF
--- a/mcp_unity_bridge/mcp_adapter.py
+++ b/mcp_unity_bridge/mcp_adapter.py
@@ -312,6 +312,28 @@ async def blender_execute_python(code: str) -> str:
 
 
 @mcp.tool()
+async def blender_execute_python_file(path: str) -> str:
+    """Ejecuta un archivo Python dentro del entorno de Blender.
+
+    El archivo debe existir y ser accesible desde la instancia de Blender que
+    recibe el comando. La respuesta incluye la salida estándar y cualquier
+    error producido durante la ejecución.
+
+    Args:
+        path: Ruta al archivo Python desde la perspectiva de Blender.
+
+    Returns:
+        Una cadena JSON con la respuesta del puente de Blender, incluyendo
+        stdout y stderr.
+    """
+
+    log.info("Blender execute_python_file: %s", path)
+    message = {"command": "execute_python_file", "params": {"path": path}}
+    response = await send_to_blender_and_get_response(message)
+    return json.dumps(response, indent=2, ensure_ascii=False)
+
+
+@mcp.tool()
 async def blender_create_cube(
     name: str = "Cube", location: Tuple[float, float, float] = (0, 0, 0)
 ) -> str:


### PR DESCRIPTION
## Summary
- Add `blender_execute_python_file` tool to forward file execution requests to Blender and expose stdout/stderr

## Testing
- `python -m py_compile mcp_unity_bridge/mcp_adapter.py`
- `pytest` *(fails: ConnectionRefusedError connecting to 127.0.0.1:8001)*

------
https://chatgpt.com/codex/tasks/task_e_68ae9ede3ed48323a70f204188c8af72